### PR TITLE
fix: update test path so that vscode can recognize these tests

### DIFF
--- a/src/sample_cpu_project/tests/test_dummy.py
+++ b/src/sample_cpu_project/tests/test_dummy.py
@@ -1,4 +1,4 @@
-import sample_main
+from sample_cpu_project import sample_main
 
 
 def test_main():

--- a/src/sample_pytorch_gpu_project/.devcontainer/devcontainer.json
+++ b/src/sample_pytorch_gpu_project/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
         ],
         "python.linting.mypyEnabled": true,
         "python.testing.pytestEnabled": true,
-        "python.pythonPath": "/opt/conda/envs/noise-dl/bin/python",
+        "python.pythonPath": "python",
         "[python]": {
             "editor.formatOnSave": true,
             "editor.codeActionsOnSave": {

--- a/src/sample_pytorch_gpu_project/tests/test_dummy.py
+++ b/src/sample_pytorch_gpu_project/tests/test_dummy.py
@@ -1,4 +1,4 @@
-import sample_main
+from sample_pytorch_gpu_project import sample_main
 
 
 def test_main():


### PR DESCRIPTION
# Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Currently, vscode can't recognize test file locations as they are not discoverable. 
This PR updates the import path for example from
`import sample_main`
to
`from sample_cpu_project import sample_main`

pytest.ini has 
[pytest]
pythonpath = src

so now those test files are recognized and users can use vscode UI feature as well as follows:

![image](https://github.com/microsoft/dstoolkit-devcontainers/assets/7400827/2948f281-1582-4f47-b9d1-7ba31d24863a)



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

* [ ] Yes
* [x] No

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". -->

* [x] No PII in logs or output
* [x] Made corresponding changes to the documentation
* [x] All new packages used are included in requirements.txt
* [x] Functions use type hints, and there are no type hint errors

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Documentation content changes
* [ ] Experiment notebook
