### PR TITLE
fix: Add gpu support to docker-compose file

### DIFF
--- a/src/sample_pytorch_gpu_project/.devcontainer/docker-compose.yml
+++ b/src/sample_pytorch_gpu_project/.devcontainer/docker-compose.yml
@@ -9,3 +9,10 @@ services:
       # Mount the root folder that contains .git
       - ../../..:/workspace:cached
     command: /bin/sh -c "while sleep 1000; do :; done"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]


### PR DESCRIPTION
# Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR adds gpu support to gpu container. With Docker Compose version v2.18.1, when I built gpu container, nvidia-smi was not working in the built gpu container. Based on this https://docs.docker.com/compose/gpu-support/, adding gpu setting in yaml fixed the issue. As gpu support was working without this option before with another docker compose version, this might be specific to certain docker compose version (likely newer versions)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

* [ ] Yes
* [x] No

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". -->

* [x] No PII in logs or output
* [x] Made corresponding changes to the documentation
* [x] All new packages used are included in requirements.txt
* [x] Functions use type hints, and there are no type hint errors

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Documentation content changes
* [ ] Experiment notebook
