### PR TITLE
refactor: updated black, flake8, mypy to use individual vscode extensions instead of deprecating python extension features

### DIFF
--- a/notebooks/.devcontainer/devcontainer.json
+++ b/notebooks/.devcontainer/devcontainer.json
@@ -28,13 +28,17 @@
                 "donjayamanne.python-environment-manager",
                 "eamodio.gitlens",
                 "GitHub.copilot",
+                "github.copilot-chat",
                 "Gruntfuggly.todo-tree",
                 "ionutvmi.path-autocomplete",
                 "marchiore.csvtomarkdown",
                 "mechatroner.rainbow-csv",
                 "ms-azure-devops.azure-pipelines",
-                "ms-python.python",
+                "ms-python.black-formatter",
+                "ms-python.flake8",
                 "ms-python.isort",
+                "ms-python.mypy-type-checker",
+                "ms-python.python",
                 "ms-toolsai.jupyter",
                 "ms-vsliveshare.vsliveshare",
                 "njpwerner.autodocstring",
@@ -44,31 +48,31 @@
             ],
             "settings": {
                 "autoDocstring.docstringFormat": "google",
-                "python.formatting.provider": "black",
+                "flake8.args": [
+                    "--max-line-length=88"
+                ],
+                "flake8.importStrategy": "fromEnvironment",
+                "isort.args": [
+                    "--profile",
+                    "black"
+                ],
+                "isort.importStrategy": "fromEnvironment",
+                "mypy-type-checker.importStrategy": "fromEnvironment",
                 "python.linting.banditEnabled": true,
                 "python.linting.banditArgs": [
                     "-r",
                     "--configfile=${workspaceFolder}/../bandit.yml"
                 ],
-                "python.linting.enabled": true,
-                "python.linting.flake8Enabled": true,
-                "python.linting.flake8Args": [
-                    "--max-line-length=88"
-                ],
-                "python.linting.mypyEnabled": true,
                 "python.testing.pytestEnabled": true,
-                "python.defaultInterpreterPath": "python",
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "[python]": {
-                    "editor.formatOnSave": true,
                     "editor.codeActionsOnSave": {
                         "source.organizeImports": true
                     },
+                    "editor.defaultFormatter": "ms-python.black-formatter",
+                    "editor.formatOnSave": true,
                     "files.trimTrailingWhitespace": true
                 },
-                "isort.args": [
-                    "--profile",
-                    "black"
-                ],
             },
         }
     },

--- a/src/sample_cpu_project/.devcontainer/devcontainer.json
+++ b/src/sample_cpu_project/.devcontainer/devcontainer.json
@@ -29,13 +29,17 @@
                 "donjayamanne.python-environment-manager",
                 "eamodio.gitlens",
                 "GitHub.copilot",
+                "github.copilot-chat",
                 "Gruntfuggly.todo-tree",
                 "ionutvmi.path-autocomplete",
                 "marchiore.csvtomarkdown",
                 "mechatroner.rainbow-csv",
                 "ms-azure-devops.azure-pipelines",
-                "ms-python.python",
+                "ms-python.black-formatter",
+                "ms-python.flake8",
                 "ms-python.isort",
+                "ms-python.mypy-type-checker",
+                "ms-python.python",
                 "ms-toolsai.jupyter",
                 "ms-vsliveshare.vsliveshare",
                 "njpwerner.autodocstring",
@@ -45,31 +49,31 @@
             ],
             "settings": {
                 "autoDocstring.docstringFormat": "google",
-                "python.formatting.provider": "black",
+                "flake8.args": [
+                    "--max-line-length=88"
+                ],
+                "flake8.importStrategy": "fromEnvironment",
+                "isort.args": [
+                    "--profile",
+                    "black"
+                ],
+                "isort.importStrategy": "fromEnvironment",
+                "mypy-type-checker.importStrategy": "fromEnvironment",
                 "python.linting.banditEnabled": true,
                 "python.linting.banditArgs": [
                     "-r",
                     "--configfile=${workspaceFolder}/../../bandit.yml"
                 ],
-                "python.linting.enabled": true,
-                "python.linting.flake8Enabled": true,
-                "python.linting.flake8Args": [
-                    "--max-line-length=88"
-                ],
-                "python.linting.mypyEnabled": true,
                 "python.testing.pytestEnabled": true,
-                "python.defaultInterpreterPath": "python",
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "[python]": {
-                    "editor.formatOnSave": true,
                     "editor.codeActionsOnSave": {
                         "source.organizeImports": true
                     },
+                    "editor.defaultFormatter": "ms-python.black-formatter",
+                    "editor.formatOnSave": true,
                     "files.trimTrailingWhitespace": true
                 },
-                "isort.args": [
-                    "--profile",
-                    "black"
-                ],
             },
         }
     },

--- a/src/sample_pytorch_gpu_project/.devcontainer/devcontainer.json
+++ b/src/sample_pytorch_gpu_project/.devcontainer/devcontainer.json
@@ -30,13 +30,17 @@
                 "donjayamanne.python-environment-manager",
                 "eamodio.gitlens",
                 "GitHub.copilot",
+                "github.copilot-chat",
                 "Gruntfuggly.todo-tree",
                 "ionutvmi.path-autocomplete",
                 "marchiore.csvtomarkdown",
                 "mechatroner.rainbow-csv",
                 "ms-azure-devops.azure-pipelines",
-                "ms-python.python",
+                "ms-python.black-formatter",
+                "ms-python.flake8",
                 "ms-python.isort",
+                "ms-python.mypy-type-checker",
+                "ms-python.python",
                 "ms-toolsai.jupyter",
                 "ms-vsliveshare.vsliveshare",
                 "njpwerner.autodocstring",
@@ -46,31 +50,31 @@
             ],
             "settings": {
                 "autoDocstring.docstringFormat": "google",
-                "python.formatting.provider": "black",
+                "flake8.args": [
+                    "--max-line-length=88"
+                ],
+                "flake8.importStrategy": "fromEnvironment",
+                "isort.args": [
+                    "--profile",
+                    "black"
+                ],
+                "isort.importStrategy": "fromEnvironment",
+                "mypy-type-checker.importStrategy": "fromEnvironment",
                 "python.linting.banditEnabled": true,
                 "python.linting.banditArgs": [
                     "-r",
                     "--configfile=${workspaceFolder}/../../bandit.yml"
                 ],
-                "python.linting.enabled": true,
-                "python.linting.flake8Enabled": true,
-                "python.linting.flake8Args": [
-                    "--max-line-length=88"
-                ],
-                "python.linting.mypyEnabled": true,
                 "python.testing.pytestEnabled": true,
-                "python.defaultInterpreterPath": "python",
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "[python]": {
-                    "editor.formatOnSave": true,
                     "editor.codeActionsOnSave": {
                         "source.organizeImports": true
                     },
+                    "editor.defaultFormatter": "ms-python.black-formatter",
+                    "editor.formatOnSave": true,
                     "files.trimTrailingWhitespace": true
                 },
-                "isort.args": [
-                    "--profile",
-                    "black"
-                ],
             },
         }
     },


### PR DESCRIPTION
- In all devcontainer.json in the repo, updated black, flake8, mypy to use individual vscode extensions instead of deprecating features in python extension
- defaultInterpreterPath is now fixed to /usr/local/bin/python

# Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

* [ ] Yes
* [x] No

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". -->

* [x] No PII in logs or output
* [x] Made corresponding changes to the documentation
* [x] All new packages used are included in requirements.txt
* [x] Functions use type hints, and there are no type hint errors

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Documentation content changes
* [ ] Experiment notebook
