### PR TITLE
feat: set default jupyter kernel to devcontainer default python and address warning in ruff by toml config update

### DIFF
--- a/notebooks/.devcontainer/devcontainer.json
+++ b/notebooks/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
                 "DavidAnson.vscode-markdownlint",
                 "donjayamanne.githistory",
                 "donjayamanne.python-environment-manager",
+                "donjayamanne.vscode-default-python-kernel",
                 "eamodio.gitlens",
                 "GitHub.copilot",
                 "github.copilot-chat",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,12 @@ extend-exclude = ["notebooks"]
 select = ["E", "F", "B", "S", "I", "N"]
 
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "**/tests/**/test_*.py" = [
     "S101", # asserts allowed in tests
+]
+"**/*.ipynb" = [
+    "B018", # allow notebooks printing out variables in the mid cell with variable names only
 ]
 
 [tool.pytest.ini_options]

--- a/src/sample_cpu_project/.devcontainer/devcontainer.json
+++ b/src/sample_cpu_project/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
                 "DavidAnson.vscode-markdownlint",
                 "donjayamanne.githistory",
                 "donjayamanne.python-environment-manager",
+                "donjayamanne.vscode-default-python-kernel",
                 "eamodio.gitlens",
                 "GitHub.copilot",
                 "github.copilot-chat",

--- a/src/sample_pytorch_gpu_project/.devcontainer/devcontainer.json
+++ b/src/sample_pytorch_gpu_project/.devcontainer/devcontainer.json
@@ -30,6 +30,7 @@
                 "DavidAnson.vscode-markdownlint",
                 "donjayamanne.githistory",
                 "donjayamanne.python-environment-manager",
+                "donjayamanne.vscode-default-python-kernel",
                 "eamodio.gitlens",
                 "GitHub.copilot",
                 "github.copilot-chat",


### PR DESCRIPTION
# Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This PR updates all devcontainer.json by adding "donjayamanne.vscode-default-python-kernel". Currently, when a new jupyter notebook is created, it doesn't automatically pick up the default python runtime that is defined in devcontainer as reported here https://github.com/microsoft/vscode/issues/130946. Adding that extension is official recommendation reported in the issue so this PR includes that to all devcontainers

This PR also addresses warning from the latest ruff like below observed in https://github.com/microsoft/dstoolkit-devcontainers/actions/runs/8522647898/job/23343294983?pr=37 by updating `pyproject.toml`

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

* [ ] Yes
* [x] No

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". -->

* [x] No PII in logs or output
* [x] Made corresponding changes to the documentation
* [x] All new packages used are included in requirements.txt
* [x] Functions use type hints, and there are no type hint errors

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Documentation content changes
* [ ] Experiment notebook
