### PR TITLE
feat: groups dependabot updates to one PR and update vscode ruff setting to the latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      pip-minor-patch-updates:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"

--- a/notebooks/.devcontainer/devcontainer.json
+++ b/notebooks/.devcontainer/devcontainer.json
@@ -44,6 +44,7 @@
                 "streetsidesoftware.code-spell-checker",
                 "timonwong.shellcheck",
                 "charliermarsh.ruff",
+                "grapecity.gc-excelviewer"
             ],
             "settings": {
                 "autoDocstring.docstringFormat": "google",
@@ -52,8 +53,8 @@
                 "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "[python]": {
                     "editor.codeActionsOnSave": {
-                        "source.organizeImports": true,
-                        "source.fixAll": true
+                        "source.fixAll": "explicit",
+                        "source.organizeImports": "explicit"
                     },
                     "editor.defaultFormatter": "charliermarsh.ruff",
                     "editor.formatOnSave": true,
@@ -61,8 +62,8 @@
                 },
                 "notebook.formatOnSave.enabled": true,
                 "notebook.codeActionsOnSave": {
-                    "source.fixAll": true,
-                    "source.organizeImports": true
+                    "notebook.source.fixAll": "explicit",
+                    "notebook.source.organizeImports": "explicit"
                 }
             },
         }

--- a/src/sample_cpu_project/.devcontainer/devcontainer.json
+++ b/src/sample_cpu_project/.devcontainer/devcontainer.json
@@ -44,6 +44,7 @@
                 "streetsidesoftware.code-spell-checker",
                 "timonwong.shellcheck",
                 "charliermarsh.ruff",
+                "grapecity.gc-excelviewer"
             ],
             "settings": {
                 "autoDocstring.docstringFormat": "google",
@@ -52,8 +53,8 @@
                 "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "[python]": {
                     "editor.codeActionsOnSave": {
-                        "source.organizeImports": true,
-                        "source.fixAll": true
+                        "source.fixAll": "explicit",
+                        "source.organizeImports.ruff": "explicit"
                     },
                     "editor.defaultFormatter": "charliermarsh.ruff",
                     "editor.formatOnSave": true,
@@ -61,9 +62,9 @@
                 },
                 "notebook.formatOnSave.enabled": true,
                 "notebook.codeActionsOnSave": {
-                    "source.fixAll": true,
-                    "source.organizeImports": true
-                }
+                    "notebook.source.fixAll": "explicit",
+                    "notebook.source.organizeImports": "explicit"
+                },
             },
         }
     },

--- a/src/sample_pytorch_gpu_project/.devcontainer/devcontainer.json
+++ b/src/sample_pytorch_gpu_project/.devcontainer/devcontainer.json
@@ -46,6 +46,7 @@
                 "streetsidesoftware.code-spell-checker",
                 "timonwong.shellcheck",
                 "charliermarsh.ruff",
+                "grapecity.gc-excelviewer"
             ],
             "settings": {
                 "autoDocstring.docstringFormat": "google",
@@ -54,8 +55,8 @@
                 "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "[python]": {
                     "editor.codeActionsOnSave": {
-                        "source.organizeImports": true,
-                        "source.fixAll": true
+                        "source.fixAll": "explicit",
+                        "source.organizeImports": "explicit"
                     },
                     "editor.defaultFormatter": "charliermarsh.ruff",
                     "editor.formatOnSave": true,
@@ -63,8 +64,8 @@
                 },
                 "notebook.formatOnSave.enabled": true,
                 "notebook.codeActionsOnSave": {
-                    "source.fixAll": true,
-                    "source.organizeImports": true
+                    "notebook.source.fixAll": "explicit",
+                    "notebook.source.organizeImports": "explicit"
                 }
             },
         }


### PR DESCRIPTION
# Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Currently, any dependabot package update results in individual PRs. This PR updates the dependabot configuration so that when python package version update is either minor or patch update, those will be grouped into one PR. This reduces review cost.

This PR also updates ruff configuration as some of the options are already deprecated by vscode. The latest configuration follows this.
https://github.com/astral-sh/ruff-vscode?tab=readme-ov-file#configuring-vs-code



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

* [ ] Yes
* [x] No

## Author pre-publish checklist
<!-- Please check check before publishing PR using "x". -->

* [x] No PII in logs or output
* [x] Made corresponding changes to the documentation
* [x] All new packages used are included in requirements.txt
* [x] Functions use type hints, and there are no type hint errors

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Documentation content changes
* [ ] Experiment notebook
